### PR TITLE
Use didDocumentOperation in Update operation

### DIFF
--- a/src/main/java/uniregistrar/driver/did/web/DidWebDriver.java
+++ b/src/main/java/uniregistrar/driver/did/web/DidWebDriver.java
@@ -129,9 +129,11 @@ public class DidWebDriver extends AbstractDriver {
 	@Override
 	public UpdateState update(UpdateRequest request) throws RegistrationException {
 		Preconditions.checkNotNull(request);
-		DIDDocument document = request.getDidDocument();
 
-		if (document == null) throw new RegistrationException(ErrorMessages.DID_DOC_IS_NULL);
+		if (request.getDidDocument() == null || request.getDidDocument().get(0) == null) throw new RegistrationException(ErrorMessages.DID_DOC_IS_NULL);
+
+		DIDDocument document = request.getDidDocument().get(0);
+
 		if (request.getDid() == null) throw new RegistrationException(ErrorMessages.DID_IS_NULL);
 
 		Path didPath = validateAndGetPath(request.getDid());

--- a/src/main/java/uniregistrar/driver/did/web/DidWebDriver.java
+++ b/src/main/java/uniregistrar/driver/did/web/DidWebDriver.java
@@ -91,7 +91,7 @@ public class DidWebDriver extends AbstractDriver {
 		boolean idExists = document.getId() != null;
 		UUID id = null;
 
-		// Checks if given DID already exists, generates a random ID if no ID is provided in the document
+		// Checks if given DID already exist, generates a random ID if no ID is provided in the document
 		Path didPath = idExists ? validateAndGetPath(document.getId().toString()) : generateNewPath(id = UUID.randomUUID());
 		if (Files.exists(didPath)) throw new RegistrationException(ErrorMessages.DID_ALREADY_EXISTS);
 
@@ -128,9 +128,7 @@ public class DidWebDriver extends AbstractDriver {
 
 	@Override
 	public UpdateState update(UpdateRequest request) throws RegistrationException {
-		Preconditions.checkNotNull(request);
-
-		if (request.getDidDocument() == null || request.getDidDocument().get(0) == null) throw new RegistrationException(ErrorMessages.DID_DOC_IS_NULL);
+		validateUpdateRequest(request);
 
 		DIDDocument document = request.getDidDocument().get(0);
 
@@ -157,6 +155,16 @@ public class DidWebDriver extends AbstractDriver {
 		updateState.setDidState(result);
 
 		return updateState;
+	}
+
+	private static void validateUpdateRequest(UpdateRequest request) throws RegistrationException {
+		Preconditions.checkNotNull(request);
+
+		if(request.getDidDocumentOperation() == null) throw new RegistrationException(ErrorMessages.DID_DOC_OP_IS_NULL);
+		if(request.getDidDocumentOperation().size()>1 || !"setDidDocument".equals(request.getDidDocumentOperation().get(0))) throw new RegistrationException(ErrorMessages.DID_DOC_OP_IS_INVALID);
+
+		if (request.getDidDocument() == null || request.getDidDocument().get(0) == null) throw new RegistrationException(ErrorMessages.DID_DOC_IS_NULL);
+		if(request.getDidDocument().size() > 1) throw new RegistrationException(ErrorMessages.MULTIPLE_DID_DOCS_IN_REQUEST);
 	}
 
 	@Override

--- a/src/main/java/uniregistrar/driver/did/web/util/ErrorMessages.java
+++ b/src/main/java/uniregistrar/driver/did/web/util/ErrorMessages.java
@@ -3,7 +3,10 @@ package uniregistrar.driver.did.web.util;
 public class ErrorMessages {
 
 	public static final String DID_ALREADY_EXISTS = "Given DID already exists!";
-	public static final String DID_DOC_IS_NULL = "DID Document is Null!";
+	public static final String DID_DOC_IS_NULL = "DID Document is null!";
+	public static final String DID_DOC_OP_IS_NULL = "DID Document Operation is null!";
+	public static final String DID_DOC_OP_IS_INVALID = "Only 'setDidDocument' DID Document Operation operation must be provided!";
+	public static final String MULTIPLE_DID_DOCS_IN_REQUEST = "Only one DIDDocument must be provided!";
 	public static final String DID_IS_NULL = "DID is Null!";
 	public static final String DID_DOESNT_EXIST = "DID does not exist!";
 	public static final String METHOD_PREFIX_MISMATCH = "Not a DID of did:web method!";

--- a/src/test/java/uniregistrar/driver/did/web/DidWebDriverTest.java
+++ b/src/test/java/uniregistrar/driver/did/web/DidWebDriverTest.java
@@ -30,6 +30,7 @@ public class DidWebDriverTest {
 	private static final String baseUrl = "https://localhost";
 	private static final String testId = "did:web:localhost:testDid42";
 	private static Map<String, Object> props;
+	private static final String DID_DOC_OP = "setDidDocument";
 	private static DidWebDriver driver;
 	private static DIDDocument testDoc;
 	private static Path absoluteBasePath;
@@ -138,6 +139,7 @@ public class DidWebDriverTest {
 		UpdateRequest request = new UpdateRequest();
 		request.setDid(createdDoc.getId().toString());
 		request.setDidDocument(List.of(updateDoc));
+		request.setDidDocumentOperation(List.of(DID_DOC_OP));
 		UpdateState state = driver.update(request);
 		DIDDocument rd = (DIDDocument) state.getDidState().get("didDocument");
 
@@ -152,6 +154,44 @@ public class DidWebDriverTest {
 		assertThrows(RegistrationException.class,
 					 () -> driver.update(new UpdateRequest()),
 					 ErrorMessages.DID_DOC_IS_NULL);
+	}
+
+	@Test
+	@DisplayName("update: with multiple docs throws error")
+	void updateWithMultipleDocsTest() {
+		UpdateRequest request = new UpdateRequest();
+		testDoc.setJsonObjectKeyValue("id", testId);
+		request.setDidDocument(List.of(testDoc, testDoc));
+
+		assertThrows(RegistrationException.class,
+				() -> driver.update(new UpdateRequest()),
+				ErrorMessages.MULTIPLE_DID_DOCS_IN_REQUEST);
+	}
+
+	@Test
+	@DisplayName("update: with multiple didDocumentOperation throws error")
+	void updateWithMultipleDocOpTest() {
+		UpdateRequest request = new UpdateRequest();
+		testDoc.setJsonObjectKeyValue("id", testId);
+		request.setDidDocument(List.of(testDoc));
+		request.setDidDocumentOperation(List.of(DID_DOC_OP,DID_DOC_OP));
+
+		assertThrows(RegistrationException.class,
+				() -> driver.update(new UpdateRequest()),
+				ErrorMessages.DID_DOC_OP_IS_INVALID);
+	}
+
+	@Test
+	@DisplayName("update: with invalid didDocumentOperation throws error")
+	void updateWithInvalidDocOpTest() {
+		UpdateRequest request = new UpdateRequest();
+		testDoc.setJsonObjectKeyValue("id", testId);
+		request.setDidDocument(List.of(testDoc));
+		request.setDidDocumentOperation(List.of("yo"));
+
+		assertThrows(RegistrationException.class,
+				() -> driver.update(new UpdateRequest()),
+				ErrorMessages.DID_DOC_OP_IS_INVALID);
 	}
 
 	@Test

--- a/src/test/java/uniregistrar/driver/did/web/DidWebDriverTest.java
+++ b/src/test/java/uniregistrar/driver/did/web/DidWebDriverTest.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -43,7 +44,7 @@ public class DidWebDriverTest {
 
 
 		props = new HashMap<>();
-		props.put("baseUrl", "https://localhost");
+		props.put("baseUrl", baseUrl);
 		props.put("basePath", absoluteBasePath.toString());
 		props.put("generatedFolder", "generated");
 
@@ -135,7 +136,8 @@ public class DidWebDriverTest {
 										   .build();
 
 		UpdateRequest request = new UpdateRequest();
-		request.setDidDocument(updateDoc);
+		request.setDid(createdDoc.getId().toString());
+		request.setDidDocument(List.of(updateDoc));
 		UpdateState state = driver.update(request);
 		DIDDocument rd = (DIDDocument) state.getDidState().get("didDocument");
 
@@ -157,7 +159,7 @@ public class DidWebDriverTest {
 	void updateWithoutDidTest() {
 
 		UpdateRequest request = new UpdateRequest();
-		request.setDidDocument(testDoc);
+		request.setDidDocument(List.of(testDoc));
 
 		assertThrows(RegistrationException.class,
 					 () -> driver.update(new UpdateRequest()),
@@ -171,7 +173,7 @@ public class DidWebDriverTest {
 
 		UpdateRequest request = new UpdateRequest();
 		testDoc.setJsonObjectKeyValue("id", testId);
-		request.setDidDocument(testDoc);
+		request.setDidDocument(List.of(testDoc));
 
 		assertThrows(RegistrationException.class,
 					 () -> driver.update(request),
@@ -200,10 +202,7 @@ public class DidWebDriverTest {
 					 ErrorMessages.DID_DOESNT_EXIST);
 	}
 
-
-	@Test
-	@DisplayName("register: with given identifier")
-	DIDDocument registerWithGivenIdTest() throws RegistrationException {
+	private DIDDocument registerWithGivenIdTest() throws RegistrationException {
 
 		CreateRequest request = new CreateRequest();
 		testDoc.setJsonObjectKeyValue("id", testId);


### PR DESCRIPTION
This PR adapts usage of `didDocumentOperation` from [DID Registration Specifications.](https://identity.foundation/did-registration/#diddocumentoperation)